### PR TITLE
Rework column naming

### DIFF
--- a/target_oracle/sinks.py
+++ b/target_oracle/sinks.py
@@ -552,11 +552,18 @@ class OracleSink(SQLSink):
             )
         return columns
 
+
     def snakecase(self, name):
-        name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-        name = re.sub('([a-z0-9])([A-Z])', r'\1_\2', name)
+        name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+        name = re.sub("([a-z0-9])([A-Z])", r"\1_\2", name)
         return name.lower()
 
+    def move_leading_underscores(self, text):
+        match = re.match(r'^(_*)(.*)', text)
+        if match:
+            result = match.group(2) + match.group(1)
+            return result
+        return text
 
     def conform_name(self, name: str, object_type: Optional[str] = None) -> str:
         """Conform a stream property name to one suitable for the target system.
@@ -569,9 +576,15 @@ class OracleSink(SQLSink):
         Returns:
             The name transformed to snake case.
         """
-        # strip non-alphanumeric characters, keeping - . _ and spaces
-        name = re.sub(r"[^a-zA-Z0-9_\-\.\s]", "", name)
+        # strip non-alphanumeric characters except _.
+        name = re.sub(r"[^a-zA-Z0-9_]+", "_", name)
+
+        # Move leading underscores to the end of the name
+        name = self.move_leading_underscores(name)
+
         # convert to snakecase
         name = self.snakecase(name)
         # replace leading digit
         return replace_leading_digit(name)
+
+

--- a/target_oracle/tests/data_files/illegal_colnames.singer
+++ b/target_oracle/tests/data_files/illegal_colnames.singer
@@ -1,0 +1,11 @@
+{"type": "SCHEMA", "stream": "test_illegal_colnames", "key_properties": ["_id"], "schema": {"type": "object", "properties": {"_id": {"type": "integer"}, "%a1%": {"type": "number"}, "#a2$": {"type": "string"}}}}
+{"type": "RECORD", "stream": "test_illegal_colnames", "record": {"_id": 1, "%a1%": 101, "#a2$": "string1"}}
+{"type": "SCHEMA", "stream": "test_illegal_colnames", "key_properties": ["_id"], "schema": {"type": "object", "properties": {"_id": {"type": "integer"}, "%a1%": {"type": "number"}, "#a2$": {"type": "string"}, "a3__": {"type": "boolean"}}}}
+{"type": "RECORD", "stream": "test_illegal_colnames", "record": {"_id": 2, "%a1%": 102, "#a2$": "string2", "a3__": true}}
+{"type": "SCHEMA", "stream": "test_illegal_colnames", "key_properties": ["_id"], "schema": {"type": "object", "properties": {"_id": {"type": "integer"}, "%a1%": {"type": "number"}, "#a2$": {"type": "string"}, "a3__": {"type": "boolean"}, "!a5": {"type": "string", "maxLength": 64}}}}
+{"type": "RECORD", "stream": "test_illegal_colnames", "record": {"_id": 3, "%a1%": 103, "#a2$": "string3", "a3__": false, "!a5": "banana"}}
+{"type": "RECORD", "stream": "test_illegal_colnames", "record": {"_id": 4, "%a1%": 104, "#a2$": "string4", "a3__": true, "!a5": "orange"}}
+{"type": "SCHEMA", "stream": "test_illegal_colnames", "key_properties": ["_id"], "schema": {"type": "object", "properties": {"_id": {"type": "integer"}, "%a1%": {"type": "number"}, "#a2$": {"type": "string"}, "a3__": {"type": "boolean"}, "!a5": {"type": "string", "maxLength": 164}, "__Semiphor.A6": {"type": "integer"}}}}
+{"type": "RECORD", "stream": "test_illegal_colnames", "record": {"_id": 5, "%a1%": 105, "#a2$": "string5", "a3__": false, "!a5": "apple", "__Semiphor.A6": 985}}
+{"type": "RECORD", "stream": "test_illegal_colnames", "record": {"_id": 6, "%a1%": 106, "#a2$": "string6", "a3__": true, "!a5": "banana", "__Semiphor.A6": 341}}
+{"type": "STATE", "value": {"test_illegal_colnames": 6}}

--- a/target_oracle/tests/test_core.py
+++ b/target_oracle/tests/test_core.py
@@ -245,3 +245,8 @@ def test_large_int(oracle_target):
 def test_db_schema(oracle_target):
     file_name = "target_schema.singer"
     singer_file_to_target(file_name, oracle_target)
+
+
+def test_illegal_colnames(oracle_target):
+    file_name = "illegal_colnames.singer"
+    singer_file_to_target(file_name, oracle_target)


### PR DESCRIPTION
- Moves leading underscores to the end
- cleans up periods etc in column names