### PR TITLE
support for CLOB

### DIFF
--- a/target_oracle/sinks.py
+++ b/target_oracle/sinks.py
@@ -37,7 +37,7 @@ class OracleConnector(SQLConnector):
 
         connection_url = sqlalchemy.engine.url.URL.create(
             # drivername="cx_oracle",
-            drivername=config["driver"],
+            drivername=config["driver_name"],
             username=config["user"],
             password=config["password"],
             host=config["host"],

--- a/target_oracle/sinks.py
+++ b/target_oracle/sinks.py
@@ -36,7 +36,7 @@ class OracleConnector(SQLConnector):
             return config["sqlalchemy_url"]
 
         connection_url = sqlalchemy.engine.url.URL.create(
-            drivername="oracle+cx_oracle",
+            drivername="blablaoracle+cx_oracle",
             username=config["user"],
             password=config["password"],
             host=config["host"],

--- a/target_oracle/sinks.py
+++ b/target_oracle/sinks.py
@@ -85,8 +85,8 @@ class OracleConnector(SQLConnector):
         if self._jsonschema_type_check(jsonschema_type, ("string",)):
             datelike_type = get_datelike_property_type(jsonschema_type)
             # Universal detection of CLOB fields
-+           if jsonschema_type.get("maxLength", 0) > 4000 or jsonschema_type.get("format", "").lower() == "clob":
-+               return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.CLOB())
+            if jsonschema_type.get("maxLength", 0) > 4000 or jsonschema_type.get("format", "").lower() == "clob":
+                return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.CLOB())
             if datelike_type == "clob":
                 return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.CLOB())
 

--- a/target_oracle/sinks.py
+++ b/target_oracle/sinks.py
@@ -36,7 +36,7 @@ class OracleConnector(SQLConnector):
             return config["sqlalchemy_url"]
 
         connection_url = sqlalchemy.engine.url.URL.create(
-            drivername="blablaoracle+cx_oracle",
+            drivername="cx_oracle",
             username=config["user"],
             password=config["password"],
             host=config["host"],

--- a/target_oracle/sinks.py
+++ b/target_oracle/sinks.py
@@ -84,6 +84,12 @@ class OracleConnector(SQLConnector):
         """
         if self._jsonschema_type_check(jsonschema_type, ("string",)):
             datelike_type = get_datelike_property_type(jsonschema_type)
+            # Universal detection of CLOB fields
++           if jsonschema_type.get("maxLength", 0) > 4000 or jsonschema_type.get("format", "").lower() == "clob":
++               return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.CLOB())
+            if datelike_type == "clob":
+                return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.CLOB())
+
             if datelike_type:
                 if datelike_type == "date-time":
                     return cast(
@@ -101,6 +107,10 @@ class OracleConnector(SQLConnector):
 
         if self._jsonschema_type_check(jsonschema_type, ("integer",)):
             return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.INTEGER())
+
+        # Detect and convert CLOB fields
+        if self._jsonschema_type_check(jsonschema_type, ("clob",)):
+           return cast(sqlalchemy.types.TypeEngine, sqlalchemy.types.CLOB())
         
         if self._jsonschema_type_check(jsonschema_type, ("number",)):
             if self.config.get("prefer_float_over_numeric", False):

--- a/target_oracle/sinks.py
+++ b/target_oracle/sinks.py
@@ -36,7 +36,8 @@ class OracleConnector(SQLConnector):
             return config["sqlalchemy_url"]
 
         connection_url = sqlalchemy.engine.url.URL.create(
-            drivername="cx_oracle",
+            # drivername="cx_oracle",
+            drivername=config["driver"],
             username=config["user"],
             password=config["password"],
             host=config["host"],


### PR DESCRIPTION
I added support for CLOB data types. Before, the code was failing, unnecessarily converting clobs to varchars. I also added configurable driver name, but this obviously needs more work (the intention was to eventually be able to use the new Oracle Python driver in thick or thin version)